### PR TITLE
Implement --hostdev-as-target

### DIFF
--- a/QCEDL.CLI/Commands/PrintGptCommand.cs
+++ b/QCEDL.CLI/Commands/PrintGptCommand.cs
@@ -33,109 +33,9 @@ internal sealed class PrintGptCommand
         {
             using var manager = new EdlManager(globalOptions);
 
-            await manager.EnsureFirehoseModeAsync();
-            await manager.ConfigureFirehoseAsync();
-
-            Logging.Log($"Attempting to read GPT from LUN {lun}...");
-
-            var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
-            // Get Storage Info to determine sector size more reliably
-            Root? storageInfo = null;
-            try
-            {
-                // Wrap GetStorageInfo in Task.Run if it's potentially blocking or synchronous
-                storageInfo = await Task.Run(() => manager.Firehose.GetStorageInfo(storageType, lun, globalOptions.Slot));
-            }
-            catch (Exception storageEx)
-            {
-                Logging.Log($"Could not get storage info for LUN {lun} (StorageType: {storageType}). Using default sector size. Error: {storageEx.Message}", LogLevel.Error);
-            }
-
-            var sectorSize = storageInfo?.StorageInfo?.BlockSize > 0 ? (uint)storageInfo.StorageInfo.BlockSize : 0;
-            if (sectorSize == 0) // Fallback if GetStorageInfo failed or returned 0
-            {
-                sectorSize = storageType switch
-                {
-                    StorageType.Nvme => 512,
-                    StorageType.Sdcc => 512,
-                    StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
-                };
-                Logging.Log($"Storage info unreliable or unavailable, using default sector size for {storageType}: {sectorSize}", LogLevel.Warning);
-            }
-
-            Logging.Log($"Using sector size: {sectorSize} bytes for LUN {lun}.", LogLevel.Debug);
-
-            // Read the first few sectors where GPT resides (Primary: 0-?, Backup: depends on disk size)
-            // Reading 34 sectors is usually safe for primary GPT header + entries (1 header + 128 entries * 128 bytes / sectorSize = ~33 sectors)
-            // Let's read a bit more just in case, but keep it reasonable. 64 sectors * 4k = 256k
-            uint sectorsToRead = 64;
-            var gptData = await Task.Run(() => manager.Firehose.Read(
-                storageType,
-                lun,
-                globalOptions.Slot,
-                sectorSize,
-                0, // Start sector
-                sectorsToRead - 1 // Last sector (inclusive)
-            ));
-
-            if (gptData == null || gptData.Length < sectorSize * 2) // Need at least MBR + GPT Header
-            {
-                Logging.Log($"Failed to read sufficient data for GPT from LUN {lun}.", LogLevel.Error);
-                return 1;
-            }
-
-            using var stream = new MemoryStream(gptData);
-            try
-            {
-                var gpt = Gpt.ReadFromStream(stream, (int)sectorSize);
-
-                if (gpt == null)
-                {
-                    Logging.Log($"No valid GPT found on LUN {lun}.", LogLevel.Warning);
-                    // Don't necessarily exit with error, maybe just no GPT exists
-                    return 0;
-                }
-
-                Logging.Log($"--- GPT Header LUN {lun} ---");
-                Logging.Log($"Signature: {gpt.Header.Signature}");
-                Logging.Log($"Revision: {gpt.Header.Revision:X8}");
-                Logging.Log($"Header Size: {gpt.Header.Size}");
-                Logging.Log($"Header CRC32: {gpt.Header.CRC32:X8}");
-                Logging.Log($"Current LBA: {gpt.Header.CurrentLBA}");
-                Logging.Log($"Backup LBA: {gpt.Header.BackupLBA}");
-                Logging.Log($"First Usable LBA: {gpt.Header.FirstUsableLBA}");
-                Logging.Log($"Last Usable LBA: {gpt.Header.LastUsableLBA}");
-                Logging.Log($"Disk GUID: {gpt.Header.DiskGUID}");
-                Logging.Log($"Partition Array LBA: {gpt.Header.PartitionArrayLBA}");
-                Logging.Log($"Partition Entry Count: {gpt.Header.PartitionEntryCount}");
-                Logging.Log($"Partition Entry Size: {gpt.Header.PartitionEntrySize}");
-                Logging.Log($"Partition Array CRC32: {gpt.Header.PartitionArrayCRC32:X8}");
-                Logging.Log($"Is Backup GPT: {gpt.IsBackup}", LogLevel.Debug);
-                Logging.Log($"--- Partitions LUN {lun} ---");
-
-                if (gpt.Partitions.Count == 0)
-                {
-                    Logging.Log("No partitions found in GPT.", LogLevel.Warning);
-                }
-                else
-                {
-                    foreach (var partition in gpt.Partitions)
-                    {
-                        // Clean up partition name (remove null terminators)
-                        var partitionName = partition.GetName().TrimEnd('\0');
-                        Logging.Log($"  Name: {partitionName}");
-                        Logging.Log($"    Type: {partition.TypeGUID}");
-                        Logging.Log($"    UID:  {partition.UID}");
-                        Logging.Log($"    LBA:  {partition.FirstLBA}-{partition.LastLBA} (Size: {(partition.LastLBA - partition.FirstLBA + 1) * sectorSize / 1024.0 / 1024.0:F2} MiB)");
-                        Logging.Log($"    Attr: {partition.Attributes:X16}", LogLevel.Debug);
-                    }
-                }
-            }
-            catch (InvalidDataException ex)
-            {
-                Logging.Log($"Error parsing GPT data from LUN {lun}: {ex.Message}", LogLevel.Error);
-                return 1;
-            }
+            return manager.IsHostDeviceMode
+                ? await ExecuteHostDeviceModeAsync(manager, lun)
+                : await ExecuteFirehoseModeAsync(manager, globalOptions, lun);
         }
         catch (FileNotFoundException ex)
         {
@@ -147,10 +47,164 @@ internal sealed class PrintGptCommand
             Logging.Log(ex.Message, LogLevel.Error);
             return 1;
         }
+        catch (PlatformNotSupportedException ex)
+        {
+            Logging.Log($"Platform Error: {ex.Message}", LogLevel.Error);
+            return 1;
+        }
         catch (Exception ex)
         {
             Logging.Log($"An unexpected error occurred in 'printgpt': {ex.Message}", LogLevel.Error);
             Logging.Log(ex.ToString(), LogLevel.Debug);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteHostDeviceModeAsync(EdlManager manager, uint lun)
+    {
+        Logging.Log("Operating in host device mode (direct MTD access)", LogLevel.Info);
+
+        if (lun != 0)
+        {
+            Logging.Log("Warning: LUN parameter is ignored in host device mode. Reading from host device.", LogLevel.Warning);
+        }
+
+        var sectorSize = manager.GetSectorSize(lun);
+        Logging.Log($"Using sector size: {sectorSize} bytes for host device.", LogLevel.Debug);
+
+        Logging.Log($"Attempting to read GPT from host device...");
+
+        // Read enough sectors for GPT (64 sectors should be sufficient)
+        const uint sectorsToRead = 64;
+        byte[] gptData;
+
+        try
+        {
+            gptData = await manager.ReadSectorsAsync(lun, 0, sectorsToRead);
+        }
+        catch (Exception ex)
+        {
+            Logging.Log($"Failed to read GPT data from host device: {ex.Message}", LogLevel.Error);
+            return 1;
+        }
+
+        if (gptData.Length < sectorSize * 2) // Need at least MBR + GPT Header
+        {
+            Logging.Log("Failed to read sufficient data for GPT from host device.", LogLevel.Error);
+            return 1;
+        }
+
+        return ProcessGptData(gptData, sectorSize, "host device");
+    }
+
+    private static async Task<int> ExecuteFirehoseModeAsync(EdlManager manager, GlobalOptionsBinder globalOptions, uint lun)
+    {
+        await manager.EnsureFirehoseModeAsync();
+        await manager.ConfigureFirehoseAsync();
+
+        Logging.Log($"Attempting to read GPT from LUN {lun}...");
+
+        var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
+        // Get Storage Info to determine sector size more reliably
+        Root? storageInfo = null;
+        try
+        {
+            // Wrap GetStorageInfo in Task.Run if it's potentially blocking or synchronous
+            storageInfo = await Task.Run(() => manager.Firehose.GetStorageInfo(storageType, lun, globalOptions.Slot));
+        }
+        catch (Exception storageEx)
+        {
+            Logging.Log($"Could not get storage info for LUN {lun} (StorageType: {storageType}). Using default sector size. Error: {storageEx.Message}", LogLevel.Error);
+        }
+
+        var sectorSize = storageInfo?.StorageInfo?.BlockSize > 0 ? (uint)storageInfo.StorageInfo.BlockSize : 0;
+        if (sectorSize == 0) // Fallback if GetStorageInfo failed or returned 0
+        {
+            sectorSize = storageType switch
+            {
+                StorageType.Nvme => 512,
+                StorageType.Sdcc => 512,
+                StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
+            };
+            Logging.Log($"Storage info unreliable or unavailable, using default sector size for {storageType}: {sectorSize}", LogLevel.Warning);
+        }
+
+        Logging.Log($"Using sector size: {sectorSize} bytes for LUN {lun}.", LogLevel.Debug);
+
+        // Read the first few sectors where GPT resides (Primary: 0-?, Backup: depends on disk size)
+        // Reading 34 sectors is usually safe for primary GPT header + entries (1 header + 128 entries * 128 bytes / sectorSize = ~33 sectors)
+        // Let's read a bit more just in case, but keep it reasonable. 64 sectors * 4k = 256k
+        uint sectorsToRead = 64;
+        var gptData = await Task.Run(() => manager.Firehose.Read(
+            storageType,
+            lun,
+            globalOptions.Slot,
+            sectorSize,
+            0, // Start sector
+            sectorsToRead - 1 // Last sector (inclusive)
+        ));
+
+        if (gptData == null || gptData.Length < sectorSize * 2) // Need at least MBR + GPT Header
+        {
+            Logging.Log($"Failed to read sufficient data for GPT from LUN {lun}.", LogLevel.Error);
+            return 1;
+        }
+
+        return ProcessGptData(gptData, sectorSize, $"LUN {lun}");
+    }
+
+    private static int ProcessGptData(byte[] gptData, uint sectorSize, string deviceDescription)
+    {
+        using var stream = new MemoryStream(gptData);
+        try
+        {
+            var gpt = Gpt.ReadFromStream(stream, (int)sectorSize);
+
+            if (gpt == null)
+            {
+                Logging.Log($"No valid GPT found on {deviceDescription}.", LogLevel.Warning);
+                // Don't necessarily exit with error, maybe just no GPT exists
+                return 0;
+            }
+
+            Logging.Log($"--- GPT Header {deviceDescription} ---");
+            Logging.Log($"Signature: {gpt.Header.Signature}");
+            Logging.Log($"Revision: {gpt.Header.Revision:X8}");
+            Logging.Log($"Header Size: {gpt.Header.Size}");
+            Logging.Log($"Header CRC32: {gpt.Header.CRC32:X8}");
+            Logging.Log($"Current LBA: {gpt.Header.CurrentLBA}");
+            Logging.Log($"Backup LBA: {gpt.Header.BackupLBA}");
+            Logging.Log($"First Usable LBA: {gpt.Header.FirstUsableLBA}");
+            Logging.Log($"Last Usable LBA: {gpt.Header.LastUsableLBA}");
+            Logging.Log($"Disk GUID: {gpt.Header.DiskGUID}");
+            Logging.Log($"Partition Array LBA: {gpt.Header.PartitionArrayLBA}");
+            Logging.Log($"Partition Entry Count: {gpt.Header.PartitionEntryCount}");
+            Logging.Log($"Partition Entry Size: {gpt.Header.PartitionEntrySize}");
+            Logging.Log($"Partition Array CRC32: {gpt.Header.PartitionArrayCRC32:X8}");
+            Logging.Log($"Is Backup GPT: {gpt.IsBackup}", LogLevel.Debug);
+            Logging.Log($"--- Partitions {deviceDescription} ---");
+
+            if (gpt.Partitions.Count == 0)
+            {
+                Logging.Log("No partitions found in GPT.", LogLevel.Warning);
+            }
+            else
+            {
+                foreach (var partition in gpt.Partitions)
+                {
+                    // Clean up partition name (remove null terminators)
+                    var partitionName = partition.GetName().TrimEnd('\0');
+                    Logging.Log($"  Name: {partitionName}");
+                    Logging.Log($"    Type: {partition.TypeGUID}");
+                    Logging.Log($"    UID:  {partition.UID}");
+                    Logging.Log($"    LBA:  {partition.FirstLBA}-{partition.LastLBA} (Size: {(partition.LastLBA - partition.FirstLBA + 1) * sectorSize / 1024.0 / 1024.0:F2} MiB)");
+                    Logging.Log($"    Attr: {partition.Attributes:X16}", LogLevel.Debug);
+                }
+            }
+        }
+        catch (InvalidDataException ex)
+        {
+            Logging.Log($"Error parsing GPT data from {deviceDescription}: {ex.Message}", LogLevel.Error);
             return 1;
         }
 

--- a/QCEDL.CLI/Commands/WritePartitionCommand.cs
+++ b/QCEDL.CLI/Commands/WritePartitionCommand.cs
@@ -2,9 +2,7 @@ using System.CommandLine;
 using System.Diagnostics;
 using QCEDL.CLI.Core;
 using QCEDL.CLI.Helpers;
-using QCEDL.NET.PartitionTable;
 using Qualcomm.EmergencyDownload.Layers.APSS.Firehose;
-using Qualcomm.EmergencyDownload.Layers.APSS.Firehose.JSON.StorageInfo;
 using Qualcomm.EmergencyDownload.Layers.APSS.Firehose.Xml.Elements;
 
 namespace QCEDL.CLI.Commands;
@@ -48,8 +46,7 @@ internal sealed class WritePartitionCommand
         FileInfo inputFile,
         uint? specifiedLun)
     {
-        Logging.Log($"Executing 'write-part' command: Partition '{partitionName}', File '{inputFile.FullName}'...",
-            LogLevel.Trace);
+        Logging.Log($"Executing 'write-part' command: Partition '{partitionName}', File '{inputFile.FullName}'...", LogLevel.Trace);
         var commandStopwatch = Stopwatch.StartNew();
 
         if (!inputFile.Exists)
@@ -67,292 +64,10 @@ internal sealed class WritePartitionCommand
         try
         {
             using var manager = new EdlManager(globalOptions);
-            await manager.EnsureFirehoseModeAsync();
-            await manager.ConfigureFirehoseAsync();
 
-            var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
-            Logging.Log($"Using storage type: {storageType}", LogLevel.Debug);
-
-            GptPartition? foundPartition = null;
-            uint actualLun = 0;
-            uint actualSectorSize = 0;
-
-            List<uint> lunsToScan = [];
-            if (specifiedLun.HasValue)
-            {
-                lunsToScan.Add(specifiedLun.Value);
-                Logging.Log($"Scanning specified LUN: {specifiedLun.Value}", LogLevel.Debug);
-            }
-            else
-            {
-                Logging.Log("No LUN specified, attempting to determine number of LUNs and scan all.", LogLevel.Debug);
-                Root? devInfo = null;
-                try
-                {
-                    devInfo = await Task.Run(() =>
-                        manager.Firehose.GetStorageInfo(storageType, 0,
-                            globalOptions.Slot)); // Check LUN 0 for num_physical
-                }
-                catch (Exception ex)
-                {
-                    Logging.Log(
-                        $"Could not get device info to determine LUN count from LUN 0. Error: {ex.Message}. Will try a default range.",
-                        LogLevel.Warning);
-                }
-
-                if (devInfo?.StorageInfo?.NumPhysical > 0)
-                {
-                    for (uint i = 0; i < devInfo.StorageInfo.NumPhysical; i++)
-                    {
-                        lunsToScan.Add(i);
-                    }
-
-                    Logging.Log(
-                        $"Device reports {devInfo.StorageInfo.NumPhysical} LUN(s). Scanning LUNs: {string.Join(", ", lunsToScan)}",
-                        LogLevel.Debug);
-                }
-                else
-                {
-                    if (storageType == StorageType.Spinor)
-                    {
-                        lunsToScan.Add(0);
-                    }
-                    else
-                    {
-                        // Fallback: scan a common range of LUNs if num_physical couldn't be determined
-                        lunsToScan.AddRange([0, 1, 2, 3, 4, 5]);
-                        Logging.Log(
-                            $"Could not determine LUN count. Scanning default LUNs: {string.Join(", ", lunsToScan)}",
-                            LogLevel.Warning);
-                    }
-                }
-            }
-
-            foreach (var currentLun in lunsToScan)
-            {
-                Logging.Log($"Scanning LUN {currentLun} for partition '{partitionName}'...", LogLevel.Debug);
-                Root? lunStorageInfo = null;
-                try
-                {
-                    lunStorageInfo = await Task.Run(() =>
-                        manager.Firehose.GetStorageInfo(storageType, currentLun, globalOptions.Slot));
-                }
-                catch (Exception storageEx)
-                {
-                    Logging.Log(
-                        $"Could not get storage info for LUN {currentLun}. Error: {storageEx.Message}. Skipping LUN.",
-                        LogLevel.Warning);
-                    continue;
-                }
-
-                var currentSectorSize = lunStorageInfo?.StorageInfo?.BlockSize > 0
-                    ? (uint)lunStorageInfo.StorageInfo.BlockSize
-                    : 0;
-                if (currentSectorSize == 0)
-                {
-                    currentSectorSize =
-                        storageType switch
-                        {
-                            StorageType.Nvme => 512,
-                            StorageType.Sdcc => 512,
-                            StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096
-                        };
-                    Logging.Log(
-                        $"Storage info for LUN {currentLun} unreliable, using default sector size for {storageType}: {currentSectorSize}",
-                        LogLevel.Warning);
-                }
-
-                Logging.Log($"Using sector size: {currentSectorSize} bytes for LUN {currentLun}.", LogLevel.Debug);
-
-                uint sectorsForGptRead = 64;
-                byte[]? gptData;
-                try
-                {
-                    gptData = await Task.Run(() => manager.Firehose.Read(storageType, currentLun, globalOptions.Slot,
-                        currentSectorSize, 0, sectorsForGptRead - 1));
-                }
-                catch (Exception readEx)
-                {
-                    Logging.Log(
-                        $"Failed to read GPT area from LUN {currentLun}. Error: {readEx.Message}. Skipping LUN.",
-                        LogLevel.Warning);
-                    continue;
-                }
-
-                if (gptData == null || gptData.Length < currentSectorSize * 2)
-                {
-                    Logging.Log($"Failed to read sufficient data for GPT from LUN {currentLun}.", LogLevel.Warning);
-                    continue;
-                }
-
-                using var stream = new MemoryStream(gptData);
-                try
-                {
-                    var gpt = Gpt.ReadFromStream(stream, (int)currentSectorSize);
-                    if (gpt != null)
-                    {
-                        foreach (var p in gpt.Partitions)
-                        {
-                            var currentPartitionName = p.GetName().TrimEnd('\0');
-                            if (currentPartitionName.Equals(partitionName, StringComparison.OrdinalIgnoreCase))
-                            {
-                                foundPartition = p;
-                                actualLun = currentLun;
-                                actualSectorSize = currentSectorSize;
-                                Logging.Log(
-                                    $"Found partition '{partitionName}' on LUN {actualLun} with sector size {actualSectorSize}.");
-                                Logging.Log(
-                                    $"  Details - Type: {p.TypeGUID}, UID: {p.UID}, LBA: {p.FirstLBA}-{p.LastLBA}",
-                                    LogLevel.Debug);
-                                break;
-                            }
-                        }
-                    }
-                }
-                catch (InvalidDataException)
-                {
-                    Logging.Log($"No valid GPT found or parse error on LUN {currentLun}.", LogLevel.Debug);
-                }
-                catch (Exception ex)
-                {
-                    Logging.Log($"Error processing GPT on LUN {currentLun}: {ex.Message}", LogLevel.Warning);
-                }
-
-                if (foundPartition.HasValue)
-                {
-                    break;
-                }
-            }
-
-            if (!foundPartition.HasValue)
-            {
-                Logging.Log(
-                    $"Error: Partition '{partitionName}' not found on " +
-                    (specifiedLun.HasValue ? $"LUN {specifiedLun.Value}." : "any scanned LUN."), LogLevel.Error);
-                return 1;
-            }
-
-            var originalFileLength = inputFile.Length;
-            long totalBytesToWriteIncludingPadding;
-            uint numSectorsForXml;
-
-            var partitionSizeInBytes = (long)(foundPartition.Value.LastLBA - foundPartition.Value.FirstLBA + 1) *
-                                       actualSectorSize;
-
-            if (originalFileLength > partitionSizeInBytes)
-            {
-                Logging.Log(
-                    $"Error: Input file size ({originalFileLength} bytes) is larger than the partition '{partitionName}' size ({partitionSizeInBytes} bytes).",
-                    LogLevel.Error);
-                return 1;
-            }
-
-            var remainder = originalFileLength % actualSectorSize;
-            if (remainder != 0)
-            {
-                totalBytesToWriteIncludingPadding = originalFileLength + (actualSectorSize - remainder);
-                Logging.Log(
-                    $"Input file size ({originalFileLength} bytes) is not a multiple of partition's sector size ({actualSectorSize} bytes). Will pad with zeros to {totalBytesToWriteIncludingPadding} bytes.",
-                    LogLevel.Warning);
-            }
-            else
-            {
-                totalBytesToWriteIncludingPadding = originalFileLength;
-            }
-
-            if (totalBytesToWriteIncludingPadding > partitionSizeInBytes)
-            {
-                Logging.Log(
-                    $"Error: Padded data size ({totalBytesToWriteIncludingPadding} bytes) would be larger than the partition '{partitionName}' size ({partitionSizeInBytes} bytes). This should not happen if original file fits.",
-                    LogLevel.Error);
-                return 1;
-            }
-
-            numSectorsForXml = (uint)(totalBytesToWriteIncludingPadding / actualSectorSize);
-
-            Logging.Log(
-                $"Data to write: {originalFileLength} bytes from file, padded to {totalBytesToWriteIncludingPadding} bytes ({numSectorsForXml} sectors).",
-                LogLevel.Debug);
-            if (totalBytesToWriteIncludingPadding < partitionSizeInBytes)
-            {
-                Logging.Log(
-                    $"Warning: Padded data size is smaller than partition size. The remaining space in partition '{partitionName}' will not be explicitly overwritten or zeroed out by this operation beyond the {totalBytesToWriteIncludingPadding} bytes written.",
-                    LogLevel.Warning);
-            }
-
-            var partStartSector = foundPartition.Value.FirstLBA;
-            if (partStartSector > uint.MaxValue)
-            {
-                Logging.Log(
-                    $"Error: Partition start LBA ({partStartSector}) exceeds uint.MaxValue, not supported by current Firehose.ProgramFromStream.",
-                    LogLevel.Error);
-                return 1;
-            }
-
-            Logging.Log(
-                $"Attempting to write {totalBytesToWriteIncludingPadding} bytes to partition '{partitionName}' (LUN {actualLun}, LBA {partStartSector})...");
-
-            long bytesWrittenReported = 0;
-            var writeStopwatch = new Stopwatch();
-
-            void ProgressAction(long current, long total)
-            {
-                bytesWrittenReported = current;
-                var percentage = total == 0 ? 100 : current * 100.0 / total;
-                var elapsed = writeStopwatch.Elapsed;
-                var speed = current / elapsed.TotalSeconds;
-                var speedStr = "N/A";
-                if (elapsed.TotalSeconds > 0.1)
-                {
-                    speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
-                        speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
-                        $"{speed:F0} B/s";
-                }
-
-                Console.Write(
-                    $"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
-            }
-
-            bool success;
-            try
-            {
-                using var fileStream = inputFile.OpenRead();
-
-                writeStopwatch.Start();
-                success = await Task.Run(() => manager.Firehose.ProgramFromStream(
-                    storageType,
-                    actualLun,
-                    globalOptions.Slot,
-                    actualSectorSize,
-                    (uint)partStartSector,
-                    numSectorsForXml,
-                    totalBytesToWriteIncludingPadding,
-                    inputFile.Name,
-                    fileStream,
-ProgressAction
-                ));
-                writeStopwatch.Stop();
-            }
-            catch (IOException ioEx)
-            {
-                Logging.Log($"IO Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
-                Console.WriteLine();
-                return 1;
-            }
-
-            Console.WriteLine(); // Newline after progress bar
-
-            if (success)
-            {
-                Logging.Log(
-                    $"Data ({bytesWrittenReported / (1024.0 * 1024.0):F2} MiB) successfully written to partition '{partitionName}' in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
-            }
-            else
-            {
-                Logging.Log($"Failed to write data to partition '{partitionName}'. Check previous logs.",
-                    LogLevel.Error);
-                return 1;
-            }
+            return manager.IsHostDeviceMode
+                ? await ExecuteHostDeviceModeAsync(manager, partitionName, inputFile, specifiedLun)
+                : await ExecuteFirehoseModeAsync(manager, globalOptions, partitionName, inputFile, specifiedLun);
         }
         catch (FileNotFoundException ex)
         {
@@ -369,6 +84,11 @@ ProgressAction
             Logging.Log($"IO Error (e.g., reading input file): {ex.Message}", LogLevel.Error);
             return 1;
         }
+        catch (PlatformNotSupportedException ex)
+        {
+            Logging.Log($"Platform Error: {ex.Message}", LogLevel.Error);
+            return 1;
+        }
         catch (Exception ex)
         {
             Logging.Log($"An unexpected error occurred in 'write-part': {ex.Message}", LogLevel.Error);
@@ -378,8 +98,263 @@ ProgressAction
         finally
         {
             commandStopwatch.Stop();
-            Logging.Log($"'write-part' command finished in {commandStopwatch.Elapsed.TotalSeconds:F2}s.",
-                LogLevel.Debug);
+            Logging.Log($"'write-part' command finished in {commandStopwatch.Elapsed.TotalSeconds:F2}s.", LogLevel.Debug);
+        }
+    }
+
+    private static async Task<int> ExecuteHostDeviceModeAsync(
+        EdlManager manager,
+        string partitionName,
+        FileInfo inputFile,
+        uint? specifiedLun)
+    {
+        Logging.Log("Operating in host device mode (direct MTD access)", LogLevel.Info);
+
+        if (specifiedLun.HasValue && specifiedLun.Value != 0)
+        {
+            Logging.Log("Warning: LUN parameter is ignored in host device mode.", LogLevel.Warning);
+        }
+
+        // Find the partition
+        Logging.Log($"Searching for partition '{partitionName}' on host device...", LogLevel.Debug);
+        var foundPartition = await manager.FindPartitionAsync(partitionName);
+
+        if (!foundPartition.HasValue)
+        {
+            Logging.Log($"Error: Partition '{partitionName}' not found on host device.", LogLevel.Error);
+            return 1;
+        }
+
+        var hostManager = manager.GetHostDeviceManager();
+        var sectorSize = hostManager.SectorSize;
+        var partition = foundPartition.Value;
+
+        var partitionSizeInBytes = (long)(partition.LastLBA - partition.FirstLBA + 1) * sectorSize;
+        var originalFileLength = inputFile.Length;
+
+        Logging.Log($"Found partition '{partitionName}': LBA {partition.FirstLBA}-{partition.LastLBA}, Size: {partitionSizeInBytes / 1024.0 / 1024.0:F2} MiB");
+
+        if (originalFileLength > partitionSizeInBytes)
+        {
+            Logging.Log($"Error: Input file size ({originalFileLength} bytes) is larger than partition '{partitionName}' size ({partitionSizeInBytes} bytes).", LogLevel.Error);
+            return 1;
+        }
+
+        // Read the input file
+        byte[] inputData;
+        try
+        {
+            inputData = await File.ReadAllBytesAsync(inputFile.FullName);
+        }
+        catch (IOException ioEx)
+        {
+            Logging.Log($"Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
+            return 1;
+        }
+
+        var remainder = originalFileLength % sectorSize;
+        if (remainder != 0)
+        {
+            var paddedSize = originalFileLength + (sectorSize - remainder);
+            Logging.Log($"Input file size ({originalFileLength} bytes) is not a multiple of sector size ({sectorSize} bytes). Will pad with zeros to {paddedSize} bytes.", LogLevel.Info);
+        }
+
+        if (originalFileLength < partitionSizeInBytes)
+        {
+            Logging.Log($"Warning: Input data size ({originalFileLength} bytes) is smaller than partition size ({partitionSizeInBytes} bytes). Only the first part of the partition will be written.", LogLevel.Warning);
+        }
+
+        Logging.Log($"Writing {originalFileLength} bytes to partition '{partitionName}' on host device...");
+
+        long bytesWrittenReported = 0;
+        var writeStopwatch = Stopwatch.StartNew();
+
+        void ProgressAction(long current, long total)
+        {
+            bytesWrittenReported = current;
+            var percentage = total == 0 ? 100 : current * 100.0 / total;
+            var elapsed = writeStopwatch.Elapsed;
+            var speed = current / elapsed.TotalSeconds;
+            var speedStr = "N/A";
+            if (elapsed.TotalSeconds > 0.1)
+            {
+                speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
+                    speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
+                    $"{speed:F0} B/s";
+            }
+            Console.Write($"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
+        }
+
+        try
+        {
+            writeStopwatch.Start();
+            await Task.Run(() => hostManager.WritePartition(partitionName, inputData, ProgressAction));
+            writeStopwatch.Stop();
+        }
+        catch (Exception ex)
+        {
+            Logging.Log($"Error during host device partition write: {ex.Message}", LogLevel.Error);
+            Console.WriteLine(); // Clear progress line
+            return 1;
+        }
+
+        Console.WriteLine(); // Newline after progress bar
+
+        Logging.Log($"Successfully wrote {bytesWrittenReported / (1024.0 * 1024.0):F2} MiB to partition '{partitionName}' in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
+        return 0;
+    }
+
+    private static async Task<int> ExecuteFirehoseModeAsync(
+        EdlManager manager,
+        GlobalOptionsBinder globalOptions,
+        string partitionName,
+        FileInfo inputFile,
+        uint? specifiedLun)
+    {
+        var foundPartitionInfo = await manager.FindPartitionWithLunAsync(partitionName, specifiedLun);
+
+        if (!foundPartitionInfo.HasValue)
+        {
+            Logging.Log($"Error: Partition '{partitionName}' not found on " +
+                       (specifiedLun.HasValue ? $"LUN {specifiedLun.Value}." : "any scanned LUN."), LogLevel.Error);
+            return 1;
+        }
+
+        var (foundPartition, actualLun) = foundPartitionInfo.Value;
+        var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
+
+        // Get sector size for the LUN where partition was found
+        uint actualSectorSize;
+        try
+        {
+            var lunStorageInfo = await Task.Run(() => manager.Firehose.GetStorageInfo(storageType, actualLun, globalOptions.Slot));
+            actualSectorSize = lunStorageInfo?.StorageInfo?.BlockSize > 0 ? (uint)lunStorageInfo.StorageInfo.BlockSize : 0;
+
+            if (actualSectorSize == 0)
+            {
+                actualSectorSize = storageType switch
+                {
+                    StorageType.Nvme => 512,
+                    StorageType.Sdcc => 512,
+                    StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
+                };
+                Logging.Log($"Storage info for LUN {actualLun} unreliable, using default sector size for {storageType}: {actualSectorSize}", LogLevel.Warning);
+            }
+        }
+        catch (Exception storageEx)
+        {
+            Logging.Log($"Could not get storage info for LUN {actualLun}. Error: {storageEx.Message}. Using default sector size.", LogLevel.Warning);
+            actualSectorSize = storageType switch
+            {
+                StorageType.Nvme => 512,
+                StorageType.Sdcc => 512,
+                StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
+            };
+        }
+
+        var originalFileLength = inputFile.Length;
+        long totalBytesToWriteIncludingPadding;
+        uint numSectorsForXml;
+
+        var partitionSizeInBytes = (long)(foundPartition.LastLBA - foundPartition.FirstLBA + 1) * actualSectorSize;
+
+        if (originalFileLength > partitionSizeInBytes)
+        {
+            Logging.Log($"Error: Input file size ({originalFileLength} bytes) is larger than the partition '{partitionName}' size ({partitionSizeInBytes} bytes).", LogLevel.Error);
+            return 1;
+        }
+
+        var remainder = originalFileLength % actualSectorSize;
+        if (remainder != 0)
+        {
+            totalBytesToWriteIncludingPadding = originalFileLength + (actualSectorSize - remainder);
+            Logging.Log($"Input file size ({originalFileLength} bytes) is not a multiple of partition's sector size ({actualSectorSize} bytes). Will pad with zeros to {totalBytesToWriteIncludingPadding} bytes.", LogLevel.Warning);
+        }
+        else
+        {
+            totalBytesToWriteIncludingPadding = originalFileLength;
+        }
+
+        if (totalBytesToWriteIncludingPadding > partitionSizeInBytes)
+        {
+            Logging.Log($"Error: Padded data size ({totalBytesToWriteIncludingPadding} bytes) would be larger than the partition '{partitionName}' size ({partitionSizeInBytes} bytes). This should not happen if original file fits.", LogLevel.Error);
+            return 1;
+        }
+
+        numSectorsForXml = (uint)(totalBytesToWriteIncludingPadding / actualSectorSize);
+
+        Logging.Log($"Data to write: {originalFileLength} bytes from file, padded to {totalBytesToWriteIncludingPadding} bytes ({numSectorsForXml} sectors).", LogLevel.Debug);
+        if (totalBytesToWriteIncludingPadding < partitionSizeInBytes)
+        {
+            Logging.Log($"Warning: Padded data size is smaller than partition size. The remaining space in partition '{partitionName}' will not be explicitly overwritten or zeroed out by this operation beyond the {totalBytesToWriteIncludingPadding} bytes written.", LogLevel.Warning);
+        }
+
+        var partStartSector = foundPartition.FirstLBA;
+        if (partStartSector > uint.MaxValue)
+        {
+            Logging.Log($"Error: Partition start LBA ({partStartSector}) exceeds uint.MaxValue, not supported by current Firehose.ProgramFromStream.", LogLevel.Error);
+            return 1;
+        }
+
+        Logging.Log($"Attempting to write {totalBytesToWriteIncludingPadding} bytes to partition '{partitionName}' (LUN {actualLun}, LBA {partStartSector})...");
+
+        long bytesWrittenReported = 0;
+        var writeStopwatch = new Stopwatch();
+
+        void ProgressAction(long current, long total)
+        {
+            bytesWrittenReported = current;
+            var percentage = total == 0 ? 100 : current * 100.0 / total;
+            var elapsed = writeStopwatch.Elapsed;
+            var speed = current / elapsed.TotalSeconds;
+            var speedStr = "N/A";
+            if (elapsed.TotalSeconds > 0.1)
+            {
+                speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
+                    speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
+                    $"{speed:F0} B/s";
+            }
+
+            Console.Write($"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
+        }
+
+        bool success;
+        try
+        {
+            using var fileStream = inputFile.OpenRead();
+
+            writeStopwatch.Start();
+            success = await Task.Run(() => manager.Firehose.ProgramFromStream(
+                storageType,
+                actualLun,
+                globalOptions.Slot,
+                actualSectorSize,
+                (uint)partStartSector,
+                numSectorsForXml,
+                totalBytesToWriteIncludingPadding,
+                inputFile.Name,
+                fileStream,
+                ProgressAction
+            ));
+            writeStopwatch.Stop();
+        }
+        catch (IOException ioEx)
+        {
+            Logging.Log($"IO Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
+            Console.WriteLine();
+            return 1;
+        }
+
+        Console.WriteLine(); // Newline after progress bar
+
+        if (success)
+        {
+            Logging.Log($"Data ({bytesWrittenReported / (1024.0 * 1024.0):F2} MiB) successfully written to partition '{partitionName}' in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
+        }
+        else
+        {
+            Logging.Log($"Failed to write data to partition '{partitionName}'. Check previous logs.", LogLevel.Error);
+            return 1;
         }
 
         return 0;

--- a/QCEDL.CLI/Commands/WriteSectorCommand.cs
+++ b/QCEDL.CLI/Commands/WriteSectorCommand.cs
@@ -49,7 +49,7 @@ internal sealed class WriteSectorCommand
         uint lun)
     {
         Logging.Log($"Executing 'write-sector' command: LUN {lun}, Start LBA {startSector}, File '{inputFile.FullName}'...", LogLevel.Trace);
-        var commandStopwatch = Stopwatch.StartNew();
+        _ = Stopwatch.StartNew();
 
         if (!inputFile.Exists)
         {
@@ -66,118 +66,11 @@ internal sealed class WriteSectorCommand
         try
         {
             using var manager = new EdlManager(globalOptions);
-            await manager.EnsureFirehoseModeAsync();
-            await manager.ConfigureFirehoseAsync();
 
-            var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
-            Logging.Log($"Using storage type: {storageType}", LogLevel.Debug);
-
-            Root? storageInfo = null;
-            try
-            {
-                storageInfo = await Task.Run(() => manager.Firehose.GetStorageInfo(storageType, lun, globalOptions.Slot));
-            }
-            catch (Exception storageEx)
-            {
-                Logging.Log($"Could not get storage info for LUN {lun} (StorageType: {storageType}). Using default sector size. Error: {storageEx.Message}", LogLevel.Warning);
-            }
-
-            var sectorSize = storageInfo?.StorageInfo?.BlockSize > 0 ? (uint)storageInfo.StorageInfo.BlockSize : 0;
-            if (sectorSize == 0)
-            {
-                sectorSize = storageType switch
-                {
-                    StorageType.Nvme => 512,
-                    StorageType.Sdcc => 512,
-                    StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
-                };
-                Logging.Log($"Storage info unreliable or unavailable, using default sector size for {storageType}: {sectorSize}", LogLevel.Warning);
-            }
-            Logging.Log($"Using sector size: {sectorSize} bytes for LUN {lun}.", LogLevel.Debug);
-
-            var originalFileLength = inputFile.Length;
-            long totalBytesToWriteIncludingPadding;
-            uint numSectorsForXml;
-
-            var remainder = originalFileLength % sectorSize;
-            if (remainder != 0)
-            {
-                totalBytesToWriteIncludingPadding = originalFileLength + (sectorSize - remainder);
-                Logging.Log($"Input file size ({originalFileLength} bytes) is not a multiple of sector size ({sectorSize} bytes). Padding with zeros to {totalBytesToWriteIncludingPadding} bytes.", LogLevel.Warning);
-            }
-            else
-            {
-                totalBytesToWriteIncludingPadding = originalFileLength;
-            }
-            numSectorsForXml = (uint)(totalBytesToWriteIncludingPadding / sectorSize);
-
-            Logging.Log($"Data to write: {originalFileLength} bytes from file, padded to {totalBytesToWriteIncludingPadding} bytes ({numSectorsForXml} sectors).", LogLevel.Debug);
-
-            if (startSector > uint.MaxValue)
-            {
-                Logging.Log($"Error: Start sector LBA ({startSector}) exceeds uint.MaxValue, which is not supported by the current Firehose.ProgramFromStream implementation's start_sector parameter.", LogLevel.Error);
-                return 1;
-            }
-
-            Logging.Log($"Attempting to write {numSectorsForXml} sectors ({totalBytesToWriteIncludingPadding} bytes) to LUN {lun}, starting at LBA {startSector}...");
-
-            long bytesWrittenReported = 0;
-            var writeStopwatch = new Stopwatch();
-
-            void ProgressAction(long current, long total)
-            {
-                bytesWrittenReported = current;
-                var percentage = total == 0 ? 100 : current * 100.0 / total;
-                var elapsed = writeStopwatch.Elapsed;
-                var speed = current / elapsed.TotalSeconds;
-                var speedStr = "N/A";
-                if (elapsed.TotalSeconds > 0.1)
-                {
-                    speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
-                        speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
-                        $"{speed:F0} B/s";
-                }
-                Console.Write($"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
-            }
-
-            bool success;
-            try
-            {
-                using var fileStream = inputFile.OpenRead();
-
-                writeStopwatch.Start();
-                success = await Task.Run(() => manager.Firehose.ProgramFromStream(
-                    storageType,
-                    lun,
-                    globalOptions.Slot,
-                    sectorSize,
-                    (uint)startSector,
-                    numSectorsForXml,
-                    totalBytesToWriteIncludingPadding,
-                    inputFile.Name,
-                    fileStream,
-ProgressAction
-                ));
-                writeStopwatch.Stop();
-            }
-            catch (IOException ioEx)
-            {
-                Logging.Log($"IO Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
-                Console.WriteLine();
-                return 1;
-            }
-
-            Console.WriteLine(); // Newline after progress bar
-
-            if (success)
-            {
-                Logging.Log($"Data ({bytesWrittenReported / (1024.0 * 1024.0):F2} MiB) written to sectors successfully in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
-            }
-            else
-            {
-                Logging.Log("Failed to write data to sectors. Check previous logs for NAK or errors.", LogLevel.Error);
-                return 1;
-            }
+            // Check if we're in host device mode
+            return manager.IsHostDeviceMode
+                ? await ExecuteHostDeviceModeAsync(manager, startSector, inputFile, lun)
+                : await ExecuteFirehoseModeAsync(manager, globalOptions, startSector, inputFile, lun);
         }
         catch (FileNotFoundException ex)
         {
@@ -194,10 +87,224 @@ ProgressAction
             Logging.Log($"IO Error (e.g., reading input file): {ex.Message}", LogLevel.Error);
             return 1;
         }
+        catch (PlatformNotSupportedException ex)
+        {
+            Logging.Log($"Platform Error: {ex.Message}", LogLevel.Error);
+            return 1;
+        }
         catch (Exception ex)
         {
             Logging.Log($"An unexpected error occurred in 'write-sector': {ex.Message}", LogLevel.Error);
             Logging.Log(ex.ToString(), LogLevel.Debug);
+            return 1;
+        }
+    }
+
+    private static async Task<int> ExecuteHostDeviceModeAsync(
+        EdlManager manager,
+        ulong startSector,
+        FileInfo inputFile,
+        uint lun)
+    {
+        Logging.Log("Operating in host device mode (direct MTD access)", LogLevel.Info);
+
+        if (lun != 0)
+        {
+            Logging.Log("Warning: LUN parameter is ignored in host device mode.", LogLevel.Warning);
+        }
+
+        var hostManager = manager.GetHostDeviceManager();
+        var sectorSize = hostManager.SectorSize;
+
+        Logging.Log($"Host device sector size: {sectorSize} bytes", LogLevel.Debug);
+
+        if (startSector > uint.MaxValue)
+        {
+            Logging.Log($"Error: Start sector LBA ({startSector}) exceeds uint.MaxValue.", LogLevel.Error);
+            return 1;
+        }
+
+        // Read the input file
+        byte[] inputData;
+        try
+        {
+            inputData = await File.ReadAllBytesAsync(inputFile.FullName);
+        }
+        catch (IOException ioEx)
+        {
+            Logging.Log($"Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
+            return 1;
+        }
+
+        var originalFileLength = inputData.Length;
+        Logging.Log($"Input file size: {originalFileLength} bytes", LogLevel.Debug);
+
+        // Calculate required sectors
+        var requiredBytes = (originalFileLength + sectorSize - 1) / sectorSize * sectorSize;
+        var requiredSectors = requiredBytes / sectorSize;
+
+        if (originalFileLength != requiredBytes)
+        {
+            Logging.Log($"Input data will be padded from {originalFileLength} to {requiredBytes} bytes ({requiredSectors} sectors)", LogLevel.Info);
+        }
+
+        Logging.Log($"Writing {requiredSectors} sectors ({requiredBytes} bytes) starting at sector {startSector}...");
+
+        long bytesWrittenReported = 0;
+        var writeStopwatch = Stopwatch.StartNew();
+
+        void ProgressAction(long current, long total)
+        {
+            bytesWrittenReported = current;
+            var percentage = total == 0 ? 100 : current * 100.0 / total;
+            var elapsed = writeStopwatch.Elapsed;
+            var speed = current / elapsed.TotalSeconds;
+            var speedStr = "N/A";
+            if (elapsed.TotalSeconds > 0.1)
+            {
+                speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
+                    speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
+                    $"{speed:F0} B/s";
+            }
+            Console.Write($"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
+        }
+
+        try
+        {
+            writeStopwatch.Start();
+            await Task.Run(() => hostManager.WriteSectors(startSector, inputData, ProgressAction));
+            writeStopwatch.Stop();
+        }
+        catch (Exception ex)
+        {
+            Logging.Log($"Error during host device write operation: {ex.Message}", LogLevel.Error);
+            Console.WriteLine(); // Clear progress line
+            return 1;
+        }
+
+        Console.WriteLine(); // Newline after progress bar
+
+        Logging.Log($"Successfully wrote {bytesWrittenReported / (1024.0 * 1024.0):F2} MiB in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
+        return 0;
+    }
+
+    private static async Task<int> ExecuteFirehoseModeAsync(
+        EdlManager manager,
+        GlobalOptionsBinder globalOptions,
+        ulong startSector,
+        FileInfo inputFile,
+        uint lun)
+    {
+        await manager.EnsureFirehoseModeAsync();
+        await manager.ConfigureFirehoseAsync();
+
+        var storageType = globalOptions.MemoryType ?? StorageType.Ufs;
+        Logging.Log($"Using storage type: {storageType}", LogLevel.Debug);
+
+        Root? storageInfo = null;
+        try
+        {
+            storageInfo = await Task.Run(() => manager.Firehose.GetStorageInfo(storageType, lun, globalOptions.Slot));
+        }
+        catch (Exception storageEx)
+        {
+            Logging.Log($"Could not get storage info for LUN {lun} (StorageType: {storageType}). Using default sector size. Error: {storageEx.Message}", LogLevel.Warning);
+        }
+
+        var sectorSize = storageInfo?.StorageInfo?.BlockSize > 0 ? (uint)storageInfo.StorageInfo.BlockSize : 0;
+        if (sectorSize == 0)
+        {
+            sectorSize = storageType switch
+            {
+                StorageType.Nvme => 512,
+                StorageType.Sdcc => 512,
+                StorageType.Spinor or StorageType.Ufs or StorageType.Nand or _ => 4096,
+            };
+            Logging.Log($"Storage info unreliable or unavailable, using default sector size for {storageType}: {sectorSize}", LogLevel.Warning);
+        }
+        Logging.Log($"Using sector size: {sectorSize} bytes for LUN {lun}.", LogLevel.Debug);
+
+        var originalFileLength = inputFile.Length;
+        long totalBytesToWriteIncludingPadding;
+        uint numSectorsForXml;
+
+        var remainder = originalFileLength % sectorSize;
+        if (remainder != 0)
+        {
+            totalBytesToWriteIncludingPadding = originalFileLength + (sectorSize - remainder);
+            Logging.Log($"Input file size ({originalFileLength} bytes) is not a multiple of sector size ({sectorSize} bytes). Padding with zeros to {totalBytesToWriteIncludingPadding} bytes.", LogLevel.Warning);
+        }
+        else
+        {
+            totalBytesToWriteIncludingPadding = originalFileLength;
+        }
+        numSectorsForXml = (uint)(totalBytesToWriteIncludingPadding / sectorSize);
+
+        Logging.Log($"Data to write: {originalFileLength} bytes from file, padded to {totalBytesToWriteIncludingPadding} bytes ({numSectorsForXml} sectors).", LogLevel.Debug);
+
+        if (startSector > uint.MaxValue)
+        {
+            Logging.Log($"Error: Start sector LBA ({startSector}) exceeds uint.MaxValue, which is not supported by the current Firehose.ProgramFromStream implementation's start_sector parameter.", LogLevel.Error);
+            return 1;
+        }
+
+        Logging.Log($"Attempting to write {numSectorsForXml} sectors ({totalBytesToWriteIncludingPadding} bytes) to LUN {lun}, starting at LBA {startSector}...");
+
+        long bytesWrittenReported = 0;
+        var writeStopwatch = new Stopwatch();
+
+        void ProgressAction(long current, long total)
+        {
+            bytesWrittenReported = current;
+            var percentage = total == 0 ? 100 : current * 100.0 / total;
+            var elapsed = writeStopwatch.Elapsed;
+            var speed = current / elapsed.TotalSeconds;
+            var speedStr = "N/A";
+            if (elapsed.TotalSeconds > 0.1)
+            {
+                speedStr = speed > 1024 * 1024 ? $"{speed / (1024 * 1024):F2} MiB/s" :
+                    speed > 1024 ? $"{speed / 1024:F2} KiB/s" :
+                    $"{speed:F0} B/s";
+            }
+            Console.Write($"\rWriting: {percentage:F1}% ({current / (1024.0 * 1024.0):F2} / {total / (1024.0 * 1024.0):F2} MiB) [{speedStr}]      ");
+        }
+
+        bool success;
+        try
+        {
+            using var fileStream = inputFile.OpenRead();
+
+            writeStopwatch.Start();
+            success = await Task.Run(() => manager.Firehose.ProgramFromStream(
+                storageType,
+                lun,
+                globalOptions.Slot,
+                sectorSize,
+                (uint)startSector,
+                numSectorsForXml,
+                totalBytesToWriteIncludingPadding,
+                inputFile.Name,
+                fileStream,
+                ProgressAction
+            ));
+            writeStopwatch.Stop();
+        }
+        catch (IOException ioEx)
+        {
+            Logging.Log($"IO Error reading input file '{inputFile.FullName}': {ioEx.Message}", LogLevel.Error);
+            Console.WriteLine();
+            return 1;
+        }
+
+        Console.WriteLine(); // Newline after progress bar
+
+        if (success)
+        {
+            Logging.Log($"Data ({bytesWrittenReported / (1024.0 * 1024.0):F2} MiB) written to sectors successfully in {writeStopwatch.Elapsed.TotalSeconds:F2}s.");
+        }
+        else
+        {
+            Logging.Log("Failed to write data to sectors. Check previous logs for NAK or errors.", LogLevel.Error);
             return 1;
         }
 

--- a/QCEDL.CLI/Core/GlobalOptionsBinder.cs
+++ b/QCEDL.CLI/Core/GlobalOptionsBinder.cs
@@ -17,7 +17,8 @@ internal sealed class GlobalOptionsBinder(
     Option<StorageType?> memoryOption,
     Option<LogLevel> logLevelOption,
     Option<ulong?> maxPayloadOption,
-    Option<uint> slotOption)
+    Option<uint> slotOption,
+    Option<string?> hostDevAsTargetOption)
     : BinderBase<GlobalOptionsBinder>
 {
     public string? LoaderPath { get; set; }
@@ -27,6 +28,7 @@ internal sealed class GlobalOptionsBinder(
     public LogLevel LogLevel { get; set; }
     public ulong? MaxPayloadSize { get; set; }
     public uint Slot { get; set; }
+    public string? HostDevAsTarget { get; set; }
 
     protected override GlobalOptionsBinder GetBoundValue(BindingContext bindingContext)
     {
@@ -39,7 +41,7 @@ internal sealed class GlobalOptionsBinder(
             Logging.Log(message, mappedCliLevel);
         };
 
-        return new(loaderOption, vidOption, pidOption, memoryOption, logLevelOption, maxPayloadOption, slotOption)
+        return new(loaderOption, vidOption, pidOption, memoryOption, logLevelOption, maxPayloadOption, slotOption, hostDevAsTargetOption)
         {
             LoaderPath = bindingContext.ParseResult.GetValueForOption(loaderOption)?.FullName,
             Vid = bindingContext.ParseResult.GetValueForOption(vidOption),
@@ -47,7 +49,8 @@ internal sealed class GlobalOptionsBinder(
             MemoryType = bindingContext.ParseResult.GetValueForOption(memoryOption),
             LogLevel = cliLogLevel,
             MaxPayloadSize = bindingContext.ParseResult.GetValueForOption(maxPayloadOption),
-            Slot = bindingContext.ParseResult.GetValueForOption(slotOption)
+            Slot = bindingContext.ParseResult.GetValueForOption(slotOption),
+            HostDevAsTarget = bindingContext.ParseResult.GetValueForOption(hostDevAsTargetOption)
         };
     }
 }

--- a/QCEDL.CLI/Core/HostDeviceManager.cs
+++ b/QCEDL.CLI/Core/HostDeviceManager.cs
@@ -1,0 +1,659 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+using QCEDL.CLI.Helpers;
+using QCEDL.NET.PartitionTable;
+
+namespace QCEDL.CLI.Core;
+
+/// <summary>
+/// Manages direct access to host MTD devices for operations bypassing USB Firehose.
+/// Currently supports SPI NOR flash devices only.
+/// </summary>
+internal sealed class HostDeviceManager : IDisposable
+{
+    private const uint MEMGETINFO = 0x80204D01;
+    private const uint MEMERASE = 0x40084D02;
+    private const int O_RDWR = 2;
+    private const int O_SYNC = 0x1000;
+    private const int SEEK_SET = 0;
+    private const uint EXPECTED_BLOCK_SIZE = 4096; // 4K blocks for SPI NOR
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MtdInfoUser
+    {
+        public byte Type;
+        public uint Flags;
+        public uint Size;
+        public uint Erasesize;
+        public uint Writesize;
+        public uint Oobsize;
+        public ulong Padding;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct EraseInfoUser
+    {
+        public uint Start;
+        public uint Length;
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int open(string pathname, int flags);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int close(int fd);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern nint read(int fd, IntPtr buf, nuint count);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern nint write(int fd, IntPtr buf, nuint count);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern long lseek(int fd, long offset, int whence);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int ioctl(int fd, uint request, IntPtr argp);
+
+    private readonly string _devicePath;
+    private int _deviceFd = -1;
+    private MtdInfoUser _mtdInfo;
+    private bool _disposed;
+
+    public uint SectorSize => _mtdInfo.Erasesize;
+    public uint DeviceSize => _mtdInfo.Size;
+
+    public HostDeviceManager(string devicePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            throw new PlatformNotSupportedException("Host device target mode is only supported on Linux.");
+        }
+
+        _devicePath = devicePath ?? throw new ArgumentNullException(nameof(devicePath));
+
+        if (!File.Exists(_devicePath))
+        {
+            throw new FileNotFoundException($"Host device not found: {_devicePath}");
+        }
+
+        InitializeDevice();
+    }
+
+    private void InitializeDevice()
+    {
+        Logging.Log($"Opening host device: {_devicePath}", LogLevel.Debug);
+
+        _deviceFd = open(_devicePath, O_RDWR | O_SYNC);
+        if (_deviceFd < 0)
+        {
+            throw new InvalidOperationException($"Failed to open {_devicePath}: {Marshal.GetLastPInvokeErrorMessage()}");
+        }
+
+        // Get MTD device info
+        var mtdPtr = Marshal.AllocHGlobal(Marshal.SizeOf<MtdInfoUser>());
+        try
+        {
+            if (ioctl(_deviceFd, MEMGETINFO, mtdPtr) < 0)
+            {
+                throw new InvalidOperationException($"{_devicePath} is not a valid MTD flash device: {Marshal.GetLastPInvokeErrorMessage()}");
+            }
+
+            _mtdInfo = Marshal.PtrToStructure<MtdInfoUser>(mtdPtr);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(mtdPtr);
+        }
+
+        // Validate device properties
+        if (_mtdInfo.Erasesize != EXPECTED_BLOCK_SIZE)
+        {
+            throw new InvalidOperationException($"Unsupported block size: {_mtdInfo.Erasesize} bytes. Expected {EXPECTED_BLOCK_SIZE} bytes for SPI NOR flash.");
+        }
+
+        Logging.Log($"Host device initialized: {_devicePath}", LogLevel.Info);
+        Logging.Log($"  Device size: {_mtdInfo.Size / (1024.0 * 1024.0):F2} MiB ({_mtdInfo.Size} bytes)", LogLevel.Info);
+        Logging.Log($"  Erase block size: {_mtdInfo.Erasesize} bytes", LogLevel.Info);
+        Logging.Log($"  Write page size: {_mtdInfo.Writesize} bytes", LogLevel.Debug);
+    }
+
+    public byte[] ReadSectors(ulong startSector, uint sectorCount)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (sectorCount == 0)
+        {
+            throw new ArgumentException("Sector count must be greater than zero", nameof(sectorCount));
+        }
+
+        var startOffset = startSector * SectorSize;
+        var readLength = sectorCount * SectorSize;
+
+        if (startOffset + readLength > DeviceSize)
+        {
+            throw new ArgumentException($"Read operation would exceed device bounds. Start: {startOffset}, Length: {readLength}, Device size: {DeviceSize}");
+        }
+
+        Logging.Log($"Reading {sectorCount} sectors ({readLength} bytes) from {_devicePath} at offset 0x{startOffset:X8} (sector {startSector})", LogLevel.Debug);
+
+        // Seek to the start position
+        if (lseek(_deviceFd, (long)startOffset, SEEK_SET) < 0)
+        {
+            throw new InvalidOperationException($"Failed to seek to offset 0x{startOffset:X8} on {_devicePath}: {Marshal.GetLastPInvokeErrorMessage()}");
+        }
+
+        var buffer = new byte[readLength];
+        var bufferPtr = Marshal.AllocHGlobal((int)readLength);
+
+        try
+        {
+            var totalRead = 0;
+            while (totalRead < readLength)
+            {
+                var remaining = (int)readLength - totalRead;
+                var bytesToRead = Math.Min(remaining, (int)SectorSize);
+
+                var bytesRead = read(_deviceFd, IntPtr.Add(bufferPtr, totalRead), (nuint)bytesToRead);
+
+                if (bytesRead < 0)
+                {
+                    throw new InvalidOperationException($"Read failed at offset 0x{startOffset + (ulong)totalRead:X8} on {_devicePath}: {Marshal.GetLastPInvokeErrorMessage()}");
+                }
+
+                if (bytesRead == 0)
+                {
+                    throw new InvalidOperationException($"Unexpected end of device at offset 0x{startOffset + (ulong)totalRead:X8} on {_devicePath}");
+                }
+
+                totalRead += (int)bytesRead;
+            }
+
+            Marshal.Copy(bufferPtr, buffer, 0, (int)readLength);
+            return buffer;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(bufferPtr);
+        }
+    }
+
+
+    public void WriteSectors(ulong startSector, byte[] data, Action<long, long>? progressCallback = null)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (data == null || data.Length == 0)
+        {
+            throw new ArgumentException("Data cannot be null or empty", nameof(data));
+        }
+
+        var startOffset = startSector * SectorSize;
+        var alignedLength = ((uint)data.Length + SectorSize - 1) / SectorSize * SectorSize;
+
+        if (startOffset + alignedLength > DeviceSize)
+        {
+            throw new ArgumentException($"Write operation would exceed device bounds. Start: {startOffset}, Length: {alignedLength}, Device size: {DeviceSize}");
+        }
+
+        Logging.Log($"Writing {data.Length} bytes to {_devicePath} at offset 0x{startOffset:X8} (sector {startSector})", LogLevel.Debug);
+
+        // Prepare data with padding if necessary
+        var writeData = data;
+        if (data.Length != alignedLength)
+        {
+            Logging.Log($"Padding data from {data.Length} to {alignedLength} bytes", LogLevel.Debug);
+            writeData = new byte[alignedLength];
+            Array.Copy(data, writeData, data.Length);
+            // Rest is zero-padded automatically
+        }
+
+        // Erase affected blocks
+        EraseBlocks((uint)startOffset, alignedLength);
+
+        // Write data
+        WriteData((uint)startOffset, writeData, progressCallback);
+
+        Logging.Log($"Successfully wrote {data.Length} bytes to {_devicePath}", LogLevel.Debug);
+    }
+
+    private void EraseBlocks(uint startOffset, uint length)
+    {
+        // Align to erase block boundaries
+        var eraseStart = startOffset / SectorSize * SectorSize;
+        var eraseLength = ((startOffset + length + SectorSize - 1) / SectorSize * SectorSize) - eraseStart;
+
+        Logging.Log($"Erasing blocks: 0x{eraseStart:X8} - 0x{eraseStart + eraseLength:X8} ({eraseLength} bytes)", LogLevel.Debug);
+
+        var erase = new EraseInfoUser
+        {
+            Start = eraseStart,
+            Length = eraseLength
+        };
+
+        var erasePtr = Marshal.AllocHGlobal(Marshal.SizeOf<EraseInfoUser>());
+        try
+        {
+            Marshal.StructureToPtr(erase, erasePtr, false);
+
+            if (ioctl(_deviceFd, MEMERASE, erasePtr) < 0)
+            {
+                throw new InvalidOperationException($"Failed to erase blocks 0x{eraseStart:X8}-0x{eraseStart + eraseLength:X8} on {_devicePath}: {Marshal.GetLastPInvokeErrorMessage()}");
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(erasePtr);
+        }
+
+        Logging.Log($"Erased {eraseLength} bytes at offset 0x{eraseStart:X8}", LogLevel.Debug);
+    }
+
+    private void WriteData(uint offset, byte[] data, Action<long, long>? progressCallback = null)
+    {
+        // Seek to the start position
+        if (lseek(_deviceFd, offset, SEEK_SET) < 0)
+        {
+            throw new InvalidOperationException($"Failed to seek to offset 0x{offset:X8} on {_devicePath}: {Marshal.GetLastPInvokeErrorMessage()}");
+        }
+
+        var dataPtr = Marshal.AllocHGlobal(data.Length);
+        try
+        {
+            Marshal.Copy(data, 0, dataPtr, data.Length);
+
+            long totalWritten = 0;
+            var writeSize = Math.Min(data.Length, (int)SectorSize);
+
+            while (totalWritten < data.Length)
+            {
+                var remaining = data.Length - totalWritten;
+                var currentWriteSize = Math.Min(writeSize, remaining);
+
+                var bytesWritten = write(_deviceFd, IntPtr.Add(dataPtr, (int)totalWritten), (nuint)currentWriteSize);
+
+                if (bytesWritten != currentWriteSize)
+                {
+                    var errorMsg = bytesWritten < 0
+                        ? Marshal.GetLastPInvokeErrorMessage()
+                        : $"Short write: {bytesWritten}/{currentWriteSize} bytes";
+                    throw new InvalidOperationException($"Write failed at offset 0x{offset + totalWritten:X8} on {_devicePath}: {errorMsg}");
+                }
+
+                totalWritten += bytesWritten;
+                progressCallback?.Invoke(totalWritten, data.Length);
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(dataPtr);
+        }
+    }
+
+    public Gpt? ReadGpt()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        Logging.Log($"Reading GPT from {_devicePath}", LogLevel.Debug);
+
+        // Read enough sectors for GPT (64 sectors should be sufficient)
+        const uint sectorsToRead = 64;
+        var gptData = ReadSectors(0, sectorsToRead);
+
+        if (gptData.Length < SectorSize * 2)
+        {
+            Logging.Log("Insufficient data read for GPT parsing", LogLevel.Warning);
+            return null;
+        }
+
+        using var stream = new MemoryStream(gptData);
+        try
+        {
+            var gpt = Gpt.ReadFromStream(stream, (int)SectorSize);
+            if (gpt != null)
+            {
+                Logging.Log($"Successfully parsed GPT with {gpt.Partitions.Count} partitions", LogLevel.Debug);
+            }
+            return gpt;
+        }
+        catch (InvalidDataException ex)
+        {
+            Logging.Log($"Failed to parse GPT from {_devicePath}: {ex.Message}", LogLevel.Warning);
+            return null;
+        }
+    }
+
+    public GptPartition? FindPartition(string partitionName)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(partitionName))
+        {
+            throw new ArgumentException("Partition name cannot be null or empty", nameof(partitionName));
+        }
+
+        var gpt = ReadGpt();
+        if (gpt == null)
+        {
+            Logging.Log($"No GPT found on {_devicePath}, cannot search for partition '{partitionName}'", LogLevel.Warning);
+            return null;
+        }
+
+        foreach (var partition in gpt.Partitions)
+        {
+            var currentPartitionName = partition.GetName().TrimEnd('\0');
+            if (currentPartitionName.Equals(partitionName, StringComparison.OrdinalIgnoreCase))
+            {
+                Logging.Log($"Found partition '{partitionName}': LBA {partition.FirstLBA}-{partition.LastLBA}, Size: {(partition.LastLBA - partition.FirstLBA + 1) * SectorSize / 1024.0 / 1024.0:F2} MiB", LogLevel.Debug);
+                return partition;
+            }
+        }
+
+        Logging.Log($"Partition '{partitionName}' not found in GPT", LogLevel.Debug);
+        return null;
+    }
+
+    public void WritePartition(string partitionName, byte[] data, Action<long, long>? progressCallback = null)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(partitionName))
+        {
+            throw new ArgumentException("Partition name cannot be null or empty", nameof(partitionName));
+        }
+
+        if (data == null || data.Length == 0)
+        {
+            throw new ArgumentException("Data cannot be null or empty", nameof(data));
+        }
+
+        var partition = FindPartition(partitionName);
+        if (!partition.HasValue)
+        {
+            throw new ArgumentException($"Partition '{partitionName}' not found on device {_devicePath}");
+        }
+
+        var partitionSizeInBytes = (long)(partition.Value.LastLBA - partition.Value.FirstLBA + 1) * SectorSize;
+
+        if (data.Length > partitionSizeInBytes)
+        {
+            throw new ArgumentException($"Data size ({data.Length} bytes) exceeds partition '{partitionName}' size ({partitionSizeInBytes} bytes)");
+        }
+
+        Logging.Log($"Writing {data.Length} bytes to partition '{partitionName}' on {_devicePath}", LogLevel.Info);
+        Logging.Log($"Partition details: LBA {partition.Value.FirstLBA}-{partition.Value.LastLBA}, Size: {partitionSizeInBytes / 1024.0 / 1024.0:F2} MiB", LogLevel.Debug);
+
+        // Write data starting at the partition's first LBA
+        WriteSectors(partition.Value.FirstLBA, data, progressCallback);
+    }
+
+    private static readonly uint[] Crc32Table = GenerateCrc32Table();
+
+    private const uint CRC32_SEED = 0;
+
+    private static uint[] GenerateCrc32Table()
+    {
+        var table = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            var crc = i;
+            for (var j = 0; j < 8; j++)
+            {
+                if ((crc & 1) != 0)
+                {
+                    crc = (crc >> 1) ^ 0xEDB88320;
+                }
+                else
+                {
+                    crc >>= 1;
+                }
+            }
+            table[i] = crc;
+        }
+        return table;
+    }
+
+    private static uint CalculateCrc32(ReadOnlySpan<byte> data, uint seed = CRC32_SEED)
+    {
+        var crc = 0xFFFFFFFF ^ seed;
+
+        foreach (var b in data)
+        {
+            crc = (crc >> 8) ^ Crc32Table[(byte)(crc ^ b)];
+        }
+
+        return crc ^ 0xFFFFFFFF;
+    }
+
+    private uint CalculateCrc32OverSectors(ulong startSector, uint numBytes)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var crc = CRC32_SEED;
+        var remainingBytes = numBytes;
+        var currentSector = startSector;
+
+        while (remainingBytes > 0)
+        {
+            var readSize = Math.Min(remainingBytes, SectorSize);
+            var numSectors = ((readSize - 1) / SectorSize) + 1; // Round up to sector size
+
+            var data = ReadSectors(currentSector, numSectors);
+
+            // Only CRC over the actual requested bytes, not the full sectors
+            var bytesToCrc = Math.Min((int)readSize, data.Length);
+            crc = CalculateCrc32(data.AsSpan(0, bytesToCrc), crc);
+
+            remainingBytes -= readSize;
+            currentSector += numSectors;
+        }
+
+        return crc;
+    }
+
+    private bool TryParseValue(string valueStr, out ulong result)
+    {
+        result = 0;
+
+        if (string.IsNullOrWhiteSpace(valueStr))
+        {
+            return false;
+        }
+
+        // Handle NUM_DISK_SECTORS expressions
+        if (valueStr.StartsWith("NUM_DISK_SECTORS"))
+        {
+            var totalSectors = DeviceSize / SectorSize;
+
+            if (valueStr.Length == "NUM_DISK_SECTORS".Length)
+            {
+                result = totalSectors;
+                return true;
+            }
+
+            if (valueStr.Length > "NUM_DISK_SECTORS".Length + 1 && valueStr["NUM_DISK_SECTORS".Length] == '-')
+            {
+                var subtractStr = valueStr["NUM_DISK_SECTORS-".Length..];
+
+                // Remove trailing dot if present
+                if (subtractStr.EndsWith('.'))
+                {
+                    subtractStr = subtractStr[..^1];
+                }
+
+                if (TryParseNumber(subtractStr, out var subtractValue))
+                {
+                    if (totalSectors >= subtractValue)
+                    {
+                        result = totalSectors - subtractValue;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        // Handle regular numbers
+        return TryParseNumber(valueStr, out result);
+    }
+
+    private static bool TryParseNumber(string str, out ulong result)
+    {
+        result = 0;
+
+        if (string.IsNullOrWhiteSpace(str))
+        {
+            return false;
+        }
+
+        // Handle hex numbers
+        if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return ulong.TryParse(str[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out result);
+        }
+
+        // Handle decimal numbers
+        return ulong.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+    }
+
+    private bool TryParseCrc32Value(string valueStr, out uint result)
+    {
+        result = 0;
+
+        if (!valueStr.StartsWith("CRC32(") || !valueStr.EndsWith(')'))
+        {
+            return false;
+        }
+
+        var innerContent = valueStr[6..^1]; // Remove "CRC32(" and ")"
+        var parts = innerContent.Split(',');
+
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        var startSectorStr = parts[0].Trim();
+        var numBytesStr = parts[1].Trim();
+
+        if (!TryParseValue(startSectorStr, out var startSector))
+        {
+            return false;
+        }
+
+        if (!TryParseNumber(numBytesStr, out var numBytesUlong))
+        {
+            return false;
+        }
+
+        if (numBytesUlong > uint.MaxValue)
+        {
+            return false;
+        }
+
+        var numBytes = (uint)numBytesUlong;
+
+        try
+        {
+            result = CalculateCrc32OverSectors(startSector, numBytes);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logging.Log($"Failed to calculate CRC32 for sectors {startSector}, {numBytes} bytes: {ex.Message}", LogLevel.Error);
+            return false;
+        }
+    }
+
+    public void ApplyPatch(string startSectorStr, uint byteOffset, uint sizeInBytes, string valueStr)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (string.IsNullOrWhiteSpace(startSectorStr))
+        {
+            throw new ArgumentException("Start sector cannot be null or empty", nameof(startSectorStr));
+        }
+
+        if (string.IsNullOrWhiteSpace(valueStr))
+        {
+            throw new ArgumentException("Value cannot be null or empty", nameof(valueStr));
+        }
+
+        if (sizeInBytes is 0 or > 8)
+        {
+            throw new ArgumentException("Size in bytes must be between 1 and 8", nameof(sizeInBytes));
+        }
+
+        if (byteOffset >= SectorSize)
+        {
+            throw new ArgumentException($"Byte offset ({byteOffset}) must be less than sector size ({SectorSize})", nameof(byteOffset));
+        }
+
+        // Parse start sector
+        if (!TryParseValue(startSectorStr, out var startSector))
+        {
+            throw new ArgumentException($"Invalid start sector value: {startSectorStr}", nameof(startSectorStr));
+        }
+
+        // Parse patch value
+        ulong patchValue;
+        if (valueStr.StartsWith("CRC32("))
+        {
+            if (!TryParseCrc32Value(valueStr, out var crc32Value))
+            {
+                throw new ArgumentException($"Invalid CRC32 expression: {valueStr}", nameof(valueStr));
+            }
+
+            patchValue = crc32Value;
+        }
+        else
+        {
+            if (!TryParseValue(valueStr, out patchValue))
+            {
+                throw new ArgumentException($"Invalid patch value: {valueStr}", nameof(valueStr));
+            }
+        }
+
+        Logging.Log($"Applying patch: sector {startSector}, offset {byteOffset}, size {sizeInBytes}, value 0x{patchValue:X}", LogLevel.Debug);
+
+        // Read the sector
+        var sectorData = ReadSectors(startSector, 1);
+
+        // Apply the patch
+        var patchBytes = new byte[8]; // Maximum size
+        if (BitConverter.IsLittleEndian)
+        {
+            var valueBytes = BitConverter.GetBytes(patchValue);
+            Array.Copy(valueBytes, patchBytes, Math.Min(valueBytes.Length, (int)sizeInBytes));
+        }
+        else
+        {
+            // Handle big-endian if needed (unlikely on most platforms)
+            var valueBytes = BitConverter.GetBytes(patchValue);
+            Array.Reverse(valueBytes);
+            Array.Copy(valueBytes, patchBytes, Math.Min(valueBytes.Length, (int)sizeInBytes));
+        }
+
+        // Copy patch bytes to sector data
+        Array.Copy(patchBytes, 0, sectorData, byteOffset, sizeInBytes);
+
+        // Write the modified sector back
+        WriteSectors(startSector, sectorData);
+
+        Logging.Log($"Applied patch to sector {startSector} at offset {byteOffset}", LogLevel.Debug);
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            if (_deviceFd >= 0)
+            {
+                _ = close(_deviceFd);
+                _deviceFd = -1;
+            }
+            _disposed = true;
+        }
+    }
+}

--- a/QCEDL.CLI/Program.cs
+++ b/QCEDL.CLI/Program.cs
@@ -82,6 +82,12 @@ slotOption.AddValidator(result =>
     }
 });
 
+var hostDevAsTargetOption = new Option<string?>(
+    name: "--hostdev-as-target",
+    description: "Treat the specified host device path as the target for operations (e.g., /dev/mtd0). " +
+                 "This bypasses USB Firehose and writes directly to the host device. " +
+                 "Currently only supports SPI NOR flash devices with 4K block size.");
+
 // --- Create Global Options Binder ---
 var globalOptionsBinder = new GlobalOptionsBinder(
     loaderOption,
@@ -90,7 +96,8 @@ var globalOptionsBinder = new GlobalOptionsBinder(
     memoryOption,
     logLevelOption,
     maxPayloadOption,
-    slotOption
+    slotOption,
+    hostDevAsTargetOption
 );
 
 // --- Define Root Command ---
@@ -103,6 +110,7 @@ rootCommand.AddGlobalOption(memoryOption);
 rootCommand.AddGlobalOption(logLevelOption);
 rootCommand.AddGlobalOption(maxPayloadOption);
 rootCommand.AddGlobalOption(slotOption);
+rootCommand.AddGlobalOption(hostDevAsTargetOption);
 
 // --- Define Commands (Add more commands here later) ---
 rootCommand.AddCommand(UploadLoaderCommand.Create(globalOptionsBinder));


### PR DESCRIPTION
Treat a specified host device path as the target for operations (e.g., /dev/mtd0). This bypasses USB Firehose and writes directly to the host device. Currently only supports SPI NOR flash devices with 4K block size.