### PR TITLE
Resolve symbolic links for program images

### DIFF
--- a/QCEDL.CLI/Commands/RawProgramCommand.cs
+++ b/QCEDL.CLI/Commands/RawProgramCommand.cs
@@ -314,6 +314,7 @@ internal sealed class RawProgramCommand
             else
             {
                 var imageFile = new FileInfo(Path.Combine(rawFile.DirectoryName ?? string.Empty, filename));
+                imageFile = imageFile.ResolveLinkTarget(true) as FileInfo ?? imageFile;
                 if (!imageFile.Exists)
                 {
                     Logging.Log($"Error: Image file '{imageFile.FullName}' (Label: {label}) not found.", LogLevel.Error);


### PR DESCRIPTION
FileInfo.Length returns 0 if the specified path is a symlink. The caller needs to explicitly resolve the symlink target.